### PR TITLE
downgrade the b2b to 1.4.2-p3 for compatibility with bodea

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "cweagans/composer-patches": "~1.0",
         "magento/composer-dependency-version-audit-plugin": "~0.1",
         "magento/composer-root-update-plugin": "^2.0.4",
-        "magento/extension-b2b": "^1.4",
+        "magento/extension-b2b": "1.4.*",
         "magento/live-search": "^4.0",
         "magento/module-page-builder-product-recommendations": "^2.0",
         "magento/module-visual-product-recommendations": "^2.0",


### PR DESCRIPTION
b2b v1.5.0 is not compatible with bodea, we are downgrading it for now. This needs to be reverted back once the bodea datapack is compatible with v1.5.0

