### PR TITLE
downgrade b2b to 1.4.* for compatibility with bodea

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "community-engineering/language-zh_cn": "*",
         "magento/composer-dependency-version-audit-plugin": "~0.1",
         "magento/composer-root-update-plugin": "~2.0",
-        "magento/extension-b2b": "^1.3",
+        "magento/extension-b2b": "1.4.*",
         "magento/live-search": "^3.0",
         "magento/magento-cloud-docker": "1.3.5.x-dev",
         "magento/magento-cloud-metapackage": "2.4.6",


### PR DESCRIPTION
b2b v1.5.0 is not compatible with bodea, we are downgrading it for now. This needs to be reverted back once the bodea datapack is compatible with v1.5.0