### PR TITLE
upgrading back the b2b composer version after the fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "cweagans/composer-patches": "~1.0",
         "magento/composer-dependency-version-audit-plugin": "~0.1",
         "magento/composer-root-update-plugin": "^2.0.4",
-        "magento/extension-b2b": "1.4.*",
+        "magento/extension-b2b": "^1.4",
         "magento/live-search": "^4.0",
         "magento/module-page-builder-product-recommendations": "^2.0",
         "magento/module-visual-product-recommendations": "^2.0",


### PR DESCRIPTION
Upgrading the b2b version as the installer module is now compatible with b2b v1.5.0.