### PR TITLE
Dsc 2.4.7 blankplus opensearch hotfix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
         "paradoxlabs/authnetcim": "5.0.1.x-dev",
         "paradoxlabs/stripe": "2.4.2.x-dev",
         "paradoxlabs/subscriptions": "4.6.0.x-dev",
-        "paradoxlabs/tokenbase": "4.6.1.x-dev"
+        "paradoxlabs/tokenbase": "4.6.1.x-dev",
+        "opensearch-project/opensearch-php": "^2.3.0"
     },
     "autoload": {
         "exclude-from-classmap": [


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
The OpenSearch was throwing this error with version 2.0.1

    Catalog Search index process error during indexation process:
    "include_type_name", "type" are not valid parameters. Allowed parameters are "allow_no_indices", "error_trace", 
    "expand_wildcards", "filter_path", "human", "ignore_unavailable", "master_timeout", "opaqueId", "pretty", "source", 
    "timeout", "write_index_only"

This happens because Live Search extension is downgrading the `opensearch-project/opensearch-php` version from **_2.3.0_** to **_2.0.1_**

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Updated composer.json file to force upgrade the `opensearch-project/opensearch-php` to version **_"^2.3.0"_**



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
