### PR TITLE
change the format for git repo url to make it compatible with composer2.9.3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,10 +85,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "repositories": [
-        {"type": "git", "url": "git@github.com:PMET-public/module-admin-configurations.git"},
-        {"type": "git", "url": "git@github.com:PMET-public/module-data-install.git"},
-        {"type": "git", "url": "git@github.com:PMET-public/module-data-install-graphql.git"},
-        {"type": "git", "url": "git@github.com:PMET-public/module-saas-data-management.git"},
+        {"type": "vcs", "url": "https://github.com/PMET-public/module-admin-configurations"},
+        {"type": "vcs", "url": "https://github.com/PMET-public/module-data-install"},
+        {"type": "vcs", "url": "https://github.com/PMET-public/module-data-install-graphql"},
+        {"type": "vcs", "url": "https://github.com/PMET-public/module-saas-data-management"},
         {
             "type": "composer",
             "url": "https://repo.magento.com/"


### PR DESCRIPTION
Issue is related to composer/composer#12715

### Description
Encountered an issue with Composer version 2.9.3 due to the format of the repo URL used in composer.json
````
Skipped branch master, Failed to parse time string (@) at position 0 (@): Unexpected character
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]               In VcsRepository.php line 423:
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]                 No valid composer.json was found in any branch or tag of git@github.com:mag
22:27:49 [admin@i-09fa950c38b0ec46e 5][NORMAL]                 ento-l10n/language-es_MX.git, could not load a package from it.
 ````
